### PR TITLE
fix: remove the useless android permissions added by rn

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.rnstarter">
+  package="com.rnstarter"
+  xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission tools:node="remove" android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission tools:node="remove" android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission tools:node="remove" android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
       android:name=".MainApplication"


### PR DESCRIPTION
Remove 3 useless Android permissions automatically added to all React Native applications:

- READ_PHONE_STATE
- WRITE_EXTERNAL_STORAGE
- READ_EXTERNAL_STORAGE