### PR TITLE
chore: bump gesture handler to latest version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 30
         targetSdkVersion = 30
-        kotlinVersion = '1.4.10'
+        kotlinVersion = '1.5.20'
         ndkVersion = "21.4.7075529"
     }
     repositories {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -363,7 +363,7 @@ PODS:
     - React-Core
     - React-Core/DevSupport
     - React-RCTNetwork
-  - RNGestureHandler (1.10.3):
+  - RNGestureHandler (2.0.0):
     - React-Core
   - RNLocalize (2.1.5):
     - React-Core
@@ -396,7 +396,7 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.9.0):
+  - RNScreens (3.10.0):
     - React-Core
     - React-RCTImage
   - SSZipArchive (2.2.3)
@@ -626,10 +626,10 @@ SPEC CHECKSUMS:
   ReactCommon: 9bac022ab71596f2b0fde1268272543184c63971
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNDevMenu: fd325b5554b61fe7f48d9205a3877cf5ee88cd7c
-  RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
+  RNGestureHandler: 51c9f32f43720c3a1c7660690a843f33acbcf01f
   RNLocalize: 74b82db20cc3895ccc25af992c644879bcec2815
   RNReanimated: 65583befd5706cc9c86ae9a081786181ced37b93
-  RNScreens: 4d79118be80f79fa1f4aa131909a1d6e86280af3
+  RNScreens: 03ba504f8c98607ad1f07808e71040e0afa335ec
   SSZipArchive: 62d4947b08730e4cda640473b0066d209ff033c9
   Yoga: 32a18c0e845e185f4a2a66ec76e1fd1f958f22fa
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-native": "0.66.3",
     "react-native-code-push": "7.0.4",
     "react-native-config": "1.4.5",
-    "react-native-gesture-handler": "1.10.3",
+    "react-native-gesture-handler": "2.0.0",
     "react-native-localize": "2.1.5",
     "react-native-mmkv": "1.5.3",
     "react-native-reanimated": "2.2.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { StatusBar } from 'react-native';
+import { StatusBar, StyleSheet } from 'react-native';
 import codePush from 'react-native-code-push';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import {
   initialWindowMetrics,
   SafeAreaProvider,
@@ -21,17 +22,25 @@ enableScreens();
 initI18n();
 getDimensionRatio();
 
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
+
 const Root = () => (
   <ThemeProvider theme={theme}>
     <StatusBar barStyle="light-content" />
 
-    <ErrorBoundary>
-      <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-        <Sandbox>
-          <AppContainer />
-        </Sandbox>
-      </SafeAreaProvider>
-    </ErrorBoundary>
+    <GestureHandlerRootView style={styles.container}>
+      <ErrorBoundary>
+        <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+          <Sandbox>
+            <AppContainer />
+          </Sandbox>
+        </SafeAreaProvider>
+      </ErrorBoundary>
+    </GestureHandlerRootView>
   </ThemeProvider>
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9072,15 +9072,15 @@ react-native-dev-menu@4.0.2:
   resolved "https://registry.npmjs.org/react-native-dev-menu/-/react-native-dev-menu-4.0.2.tgz"
   integrity sha512-tjWAULoJgOr/WjcfhFsCYaZGtQNmApm7gD5d7G/kSAWVBdEbFFuN2MIq+CxAxBsjHSwscysD1C55TCcmXP/82w==
 
-react-native-gesture-handler@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.10.3.tgz"
-  integrity sha512-cBGMi1IEsIVMgoox4RvMx7V2r6bNKw0uR1Mu1o7NbuHS6BRSVLq0dP34l2ecnPlC+jpWd3le6Yg1nrdCjby2Mw==
+react-native-gesture-handler@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.0.0.tgz#066016e2b87922511605a23b2ee00358a3216e32"
+  integrity sha512-QJxUXrWcHUyita4j+FPlAokR8i9fmD5n88uE6W5rtxNi17U1jAjnkbtplFWYutFP7naat+f77sZSmjil2+/4RA==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
-    fbjs "^3.0.0"
     hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
+    lodash "^4.17.21"
     prop-types "^15.7.2"
 
 react-native-localize@2.1.5:


### PR DESCRIPTION
Bump to a new major version of `react-native-gesture-handler` (v2)