### PR TITLE
chore: use new jsx transform

### DIFF
--- a/_templates/generators/class/component.ejs.t
+++ b/_templates/generators/class/component.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: src/components/<%= h.changeCase.pascalCase(componentName) %>/components/<%= h.changeCase.pascalCase(componentName) %>.tsx
 ---
-import React, { Component } from 'react';
+import { Component } from 'react';
 
 import { Flex, Title } from '$shared/primitives';
 

--- a/_templates/generators/class/test.ejs.t
+++ b/_templates/generators/class/test.ejs.t
@@ -3,7 +3,6 @@ to: src/components/<%= h.changeCase.pascalCase(componentName) %>/components/__te
 ---
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React from 'react';
 // import { fireEvent } from '@testing-library/react-native';
 
 import render from '$tests/utils';

--- a/_templates/generators/fc/component.ejs.t
+++ b/_templates/generators/fc/component.ejs.t
@@ -1,8 +1,6 @@
 ---
 to: src/components/<%= h.changeCase.pascalCase(componentName) %>/components/<%= h.changeCase.pascalCase(componentName) %>.tsx
 ---
-import React from 'react';
-
 import { Flex, Title } from '$shared/primitives';
 
 type Props = {

--- a/_templates/generators/fc/test.ejs.t
+++ b/_templates/generators/fc/test.ejs.t
@@ -3,7 +3,6 @@ to: src/components/<%= h.changeCase.pascalCase(componentName) %>/components/__te
 ---
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React from 'react';
 // import { fireEvent } from '@testing-library/react-native';
 
 import render from '$tests/utils';

--- a/_templates/generators/page/componentFile.ejs.t
+++ b/_templates/generators/page/componentFile.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: src/components/<%= h.changeCase.pascalCase(componentName) %>/components/<%= h.changeCase.pascalCase(componentName) %>.tsx
 ---
-import React, { Component } from 'react';
+import { Component } from 'react';
 
 import { Flex, Title } from '$shared/primitives';
 import SafeView from '$shared/SafeView';

--- a/_templates/generators/page/componentTest.ejs.t
+++ b/_templates/generators/page/componentTest.ejs.t
@@ -3,7 +3,6 @@ to: src/components/<%= h.changeCase.pascalCase(componentName) %>/components/__te
 ---
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React from 'react';
 // import { fireEvent } from '@testing-library/react-native';
 
 import render from '$tests/utils';

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,11 +1,22 @@
 module.exports = {
-  presets: ['module:metro-react-native-babel-preset'],
+  presets: [
+    [
+      'module:metro-react-native-babel-preset',
+      { useTransformReactJSXExperimental: true },
+    ],
+  ],
   env: {
     production: {
       plugins: ['transform-remove-console'],
     },
   },
   plugins: [
+    [
+      '@babel/plugin-transform-react-jsx',
+      {
+        runtime: 'automatic',
+      },
+    ],
     [
       'babel-plugin-root-import',
       {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.16.0",
+    "@babel/plugin-transform-react-jsx": "7.16.0",
     "@babel/runtime": "7.16.3",
     "@commitlint/cli": "15.0.0",
     "@commitlint/config-conventional": "15.0.0",
@@ -103,7 +104,7 @@
     "chalk": "4.1.2",
     "detox": "19.1.0",
     "eslint": "8.3.0",
-    "eslint-config-tsyirvo-react-native": "1.0.2",
+    "eslint-config-tsyirvo-react-native": "1.0.3",
     "husky": "7.0.4",
     "hygen": "6.1.0",
     "imageoptim": "0.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { StatusBar, StyleSheet } from 'react-native';
 import codePush from 'react-native-code-push';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';

--- a/src/components/errorBoundary/ErrorBoundary.tsx
+++ b/src/components/errorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ErrorInfo, ReactElement } from 'react';
+import { Component, ErrorInfo, ReactElement } from 'react';
 
 import { Button, Flex, Text, Title } from '$components/shared/primitives';
 import SafeView from '$components/shared/SafeView';

--- a/src/components/home/components/Header.tsx
+++ b/src/components/home/components/Header.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ImageBackground } from 'react-native';
 
 import { Flex, Text } from '$components/shared/primitives';

--- a/src/components/home/components/Home.tsx
+++ b/src/components/home/components/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { ScrollView } from 'react-native';
 
 import { Button, Flex, Text, Title } from '$components/shared/primitives';

--- a/src/components/home/components/Informations.tsx
+++ b/src/components/home/components/Informations.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Platform } from 'react-native';
 
 import { Text, Title } from '$components/shared/primitives';

--- a/src/components/home/components/__tests__/Home.test.tsx
+++ b/src/components/home/components/__tests__/Home.test.tsx
@@ -4,7 +4,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { fireEvent } from '@testing-library/react-native';
-import React from 'react';
 
 import render from '$tests/utils';
 

--- a/src/components/otherPage/components/OtherPage.tsx
+++ b/src/components/otherPage/components/OtherPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 
 import { Button, Flex, Text, Title } from '$components/shared/primitives';
 import SafeView from '$components/shared/SafeView';

--- a/src/components/otherPage/components/__tests__/OtherPage.test.tsx
+++ b/src/components/otherPage/components/__tests__/OtherPage.test.tsx
@@ -4,7 +4,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { fireEvent } from '@testing-library/react-native';
-import React from 'react';
 
 import render from '$tests/utils';
 

--- a/src/components/shared/FallbackLoader.tsx
+++ b/src/components/shared/FallbackLoader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Text } from '$components/shared/primitives';
 

--- a/src/components/shared/SafeView.tsx
+++ b/src/components/shared/SafeView.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   SafeAreaView,
   NativeSafeAreaViewProps,

--- a/src/components/shared/primitives/Button/Button.tsx
+++ b/src/components/shared/primitives/Button/Button.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { Pressable, PressableProps } from 'react-native';
 import styled from 'styled-components';
 import {

--- a/src/components/shared/primitives/Input/Input.tsx
+++ b/src/components/shared/primitives/Input/Input.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { TextInput, TextInputProps } from 'react-native';
 import styled from 'styled-components';
 

--- a/src/components/shared/primitives/__tests__/Button.test.tsx
+++ b/src/components/shared/primitives/__tests__/Button.test.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
 import { fireEvent } from '@testing-library/react-native';
-import React from 'react';
 import { Text } from 'react-native';
 
 import render from '$tests/utils';

--- a/src/components/shared/primitives/__tests__/Input.test.tsx
+++ b/src/components/shared/primitives/__tests__/Input.test.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
 import { fireEvent } from '@testing-library/react-native';
-import React from 'react';
 
 import render from '$tests/utils';
 

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,6 +1,5 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
-import React from 'react';
 
 import i18n from '$i18n/config';
 

--- a/src/sandbox/Sandbox.tsx
+++ b/src/sandbox/Sandbox.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
-import React, { ReactElement, Suspense, useEffect, useState } from 'react';
+import { ReactElement, Suspense, useEffect, useState } from 'react';
 
 import FallbackLoader from '$components/shared/FallbackLoader';
 

--- a/src/sandbox/components/designSystem/DesignSystem.sandbox.tsx
+++ b/src/sandbox/components/designSystem/DesignSystem.sandbox.tsx
@@ -1,5 +1,4 @@
 import { useNavigation } from '@react-navigation/core';
-import React from 'react';
 
 import { Box } from '$components/shared/primitives';
 import { DesignSystemScreenNavigationProp } from '$sandbox/navigation/DebugStack.types';

--- a/src/sandbox/components/designSystem/FallbackLoader.sandbox.tsx
+++ b/src/sandbox/components/designSystem/FallbackLoader.sandbox.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView } from 'react-native';
 
 import FallbackLoader from '$components/shared/FallbackLoader';

--- a/src/sandbox/components/menu/Components.tsx
+++ b/src/sandbox/components/menu/Components.tsx
@@ -1,5 +1,4 @@
 import { useNavigation } from '@react-navigation/core';
-import React from 'react';
 
 import { MenuScreenNavigationProp } from '$sandbox/navigation/DebugStack.types';
 

--- a/src/sandbox/components/menu/Core.tsx
+++ b/src/sandbox/components/menu/Core.tsx
@@ -1,5 +1,4 @@
 import { useNavigation } from '@react-navigation/core';
-import React from 'react';
 
 import { MenuScreenNavigationProp } from '$sandbox/navigation/DebugStack.types';
 

--- a/src/sandbox/components/menu/Flows.tsx
+++ b/src/sandbox/components/menu/Flows.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import MenuCategory from './components/MenuCategory';
 
 const Flows = () => {

--- a/src/sandbox/components/menu/Menu.tsx
+++ b/src/sandbox/components/menu/Menu.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView } from 'react-native';
 
 import { Box } from '$components/shared/primitives';

--- a/src/sandbox/components/menu/components/CenteredContent.tsx
+++ b/src/sandbox/components/menu/components/CenteredContent.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Flex } from '$components/shared/primitives';
 import { BoxProps } from '$components/shared/primitives/Box/Box.types';

--- a/src/sandbox/components/menu/components/MenuCategory.tsx
+++ b/src/sandbox/components/menu/components/MenuCategory.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Box, Text } from '$components/shared/primitives';
 

--- a/src/sandbox/components/menu/components/MenuLine.tsx
+++ b/src/sandbox/components/menu/components/MenuLine.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Pressable } from 'react-native';
 
 import { Box, Text } from '$components/shared/primitives';

--- a/src/sandbox/components/menu/components/SandboxItem.tsx
+++ b/src/sandbox/components/menu/components/SandboxItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import { Flex, Text } from '$components/shared/primitives';
 

--- a/src/sandbox/components/menu/components/Separator.tsx
+++ b/src/sandbox/components/menu/components/Separator.tsx
@@ -1,7 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React from 'react';
-
 import { Box } from '$components/shared/primitives';
 import { BoxProps } from '$components/shared/primitives/Box/Box.types';
 

--- a/src/sandbox/components/primitives/Box.sandbox.tsx
+++ b/src/sandbox/components/primitives/Box.sandbox.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView } from 'react-native';
 
 import { Box } from '$components/shared/primitives';

--- a/src/sandbox/components/primitives/Button.sandbox.tsx
+++ b/src/sandbox/components/primitives/Button.sandbox.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView } from 'react-native';
 
 import { Button, Text } from '$components/shared/primitives';

--- a/src/sandbox/components/primitives/Input.sandbox.tsx
+++ b/src/sandbox/components/primitives/Input.sandbox.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView } from 'react-native';
 
 import { Input } from '$components/shared/primitives';

--- a/src/sandbox/components/primitives/Primitives.sandbox.tsx
+++ b/src/sandbox/components/primitives/Primitives.sandbox.tsx
@@ -1,5 +1,4 @@
 import { useNavigation } from '@react-navigation/core';
-import React from 'react';
 
 import { Box } from '$components/shared/primitives';
 import { PrimitivesScreenNavigationProp } from '$sandbox/navigation/DebugStack.types';

--- a/src/sandbox/components/primitives/Text.sandbox.tsx
+++ b/src/sandbox/components/primitives/Text.sandbox.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView } from 'react-native';
 
 import { Text } from '$components/shared/primitives';

--- a/src/sandbox/components/theme/Colors.sandbox.tsx
+++ b/src/sandbox/components/theme/Colors.sandbox.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView } from 'react-native';
 
 import { Box, Text } from '$components/shared/primitives';

--- a/src/sandbox/components/theme/FontSizes.sandbox.tsx
+++ b/src/sandbox/components/theme/FontSizes.sandbox.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView } from 'react-native';
 
 import { Text, Title } from '$components/shared/primitives';

--- a/src/sandbox/components/theme/Radiuses.sandbox.tsx
+++ b/src/sandbox/components/theme/Radiuses.sandbox.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ScrollView } from 'react-native';
 
 import { Box, Text } from '$components/shared/primitives';

--- a/src/sandbox/components/theme/Spaces.sandbox.tsx
+++ b/src/sandbox/components/theme/Spaces.sandbox.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 import { ScrollView } from 'react-native';
 
 import { Box, Text } from '$components/shared/primitives';

--- a/src/sandbox/components/theme/Theme.sandbox.tsx
+++ b/src/sandbox/components/theme/Theme.sandbox.tsx
@@ -1,5 +1,4 @@
 import { useNavigation } from '@react-navigation/core';
-import React from 'react';
 
 import { Box } from '$components/shared/primitives';
 import { ThemeScreenNavigationProp } from '$sandbox/navigation/DebugStack.types';

--- a/src/sandbox/navigation/DebugStack.tsx
+++ b/src/sandbox/navigation/DebugStack.tsx
@@ -1,6 +1,6 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 
 import FallbackLoader from '$components/shared/FallbackLoader';
 

--- a/src/tests/utils.tsx
+++ b/src/tests/utils.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
 import { render as rtlRender, RenderAPI } from '@testing-library/react-native';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { ThemeProvider } from 'styled-components';
 
 import { initI18n } from '$i18n/config';

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,7 +589,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-transform-react-jsx@^7.0.0":
+"@babel/plugin-transform-react-jsx@7.16.0", "@babel/plugin-transform-react-jsx@^7.0.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.0.tgz"
   integrity sha512-rqDgIbukZ44pqq7NIRPGPGNklshPkvlmvqjdx3OZcGPk4zGIenYkxDTvl3LsSL8gqcc3ZzGmXPE6hR/u/voNOw==
@@ -4472,10 +4472,10 @@ eslint-config-prettier@8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
-eslint-config-tsyirvo-react-native@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-tsyirvo-react-native/-/eslint-config-tsyirvo-react-native-1.0.2.tgz#c2e9d50161e7e8bf14d7ac8c8ba526f450738fb5"
-  integrity sha512-jtHnFwBqnsKRNKTumKgS+oE6Z2VuI166G7dZa3LZ05YX3Bkagrn8qQ+IPkCLIIFKQwayZE3zZizWKUZu90RX1Q==
+eslint-config-tsyirvo-react-native@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-config-tsyirvo-react-native/-/eslint-config-tsyirvo-react-native-1.0.3.tgz#ec9ac974dda870d7be4182c84a3b4c3620bc6629"
+  integrity sha512-AKVN4/c49dHpRqLWPSNN++OpNvd5Su8cehGi8YNBzVQkx/uSkptmasbPo94A6M0JprG7Ho/akLkzFThmaUqsQw==
   dependencies:
     "@typescript-eslint/eslint-plugin" "5.4.0"
     "@typescript-eslint/parser" "5.4.0"


### PR DESCRIPTION
Use the new `JSX` transform, so no need to have `React` in scope anymore.