### PR TITLE
feat: add post merge hook

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+function changed {
+    git diff --name-only HEAD@{1} HEAD | grep "^$1" >/dev/null 2>&1
+}
+
+echo 'Checking for changes in yarn.lock...'
+
+if changed 'yarn.lock'; then
+    echo "📦 yarn.lock changed. Run yarn to bring your dependencies up to date."
+    yarn
+fi
+
+echo 'You are up to date :)'
+
+echo 'If necessary, you can generate again the native code.'
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
     "//// MISC ////": "",
     "perf:bundle": "npx react-native-bundle-visualizer",
     "prepare": "husky install",
-    "postinstall": "patch-package"
+    "postinstall": "husky install && patch-package",
+    "prepack": "pinst --disable",
+    "postpack": "pinst --enable"
   },
   "dependencies": {
     "@react-native-masked-view/masked-view": "0.2.9",
@@ -146,6 +148,7 @@
     "jest-expo": "^49.0.0",
     "lint-staged": "14.0.1",
     "patch-package": "8.0.0",
+    "pinst": "^3.0.0",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "3.0.3",
     "sharp": "0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14138,6 +14138,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pinst@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pinst@npm:3.0.0"
+  bin:
+    pinst: bin.js
+  checksum: 4ae48a6a60f79c37071233af51b4d91bfc85cfa3c12b66ccda60cdb642b4d14a4ab0cb3587afc55b1f6192cea1772a5e4822026a0d0d3528296edef00cc2d61f
+  languageName: node
+  linkType: hard
+
 "pirates@npm:^4.0.1, pirates@npm:^4.0.4, pirates@npm:^4.0.5":
   version: 4.0.5
   resolution: "pirates@npm:4.0.5"
@@ -15410,6 +15419,7 @@ __metadata:
     lodash: 4.17.21
     mixpanel-react-native: 2.3.1
     patch-package: 8.0.0
+    pinst: ^3.0.0
     postinstall-postinstall: ^2.1.0
     prettier: 3.0.3
     react: 18.2.0


### PR DESCRIPTION
Re-enable Husky after migrating the Yarn v2.
Add a new `post-merge` hook